### PR TITLE
Clicking an un-herped comment re-herps it

### DIFF
--- a/chrome+firefox/src/herp.js
+++ b/chrome+firefox/src/herp.js
@@ -31,7 +31,7 @@ var derpComment = function(comment) {
       comment.textContent = comment.derped ? derpString() : comment.derpOriginal;
     };
 
-    // add derped class for the selector
+    // add derped class
     comment.classList.add('derped');
 
     // change the contents

--- a/chrome+firefox/src/herp.js
+++ b/chrome+firefox/src/herp.js
@@ -9,21 +9,29 @@ var derpString = function() {
   for (x=0; x<=randomLength; x++) {
     returnString += (Math.floor(Math.random()*2) ? 'herp ' : 'derp ');
   }
-  
+
   return returnString;
 }
 
 // derps a comment
 var derpComment = function(comment) {
+
+    // indicate that this comment is derped
+    comment.derped = true;
+
     // preserve the original contents
     comment.derpOriginal = comment.textContent;
 
-    // revert to the original when clicked
+    // switch between derped and underped when clicked
     comment.onclick = function() {
-      comment.textContent = comment.derpOriginal;
+      // invert derp value
+      comment.derped = !comment.derped;
+
+      // change contents to either a new random derp string or the original comment
+      comment.textContent = comment.derped ? derpString() : comment.derpOriginal;
     };
-    
-    // add derped class
+
+    // add derped class for the selector
     comment.classList.add('derped');
 
     // change the contents


### PR DESCRIPTION
Because sometimes you regret un-herpderping.

I've been wanting to see this feature for a bit, so here it is.

I'd rather not save the herped string for a simple reason: space. If we're saving a string that's a few words long for every comment on a youtube page we could significantly increase the space taken up in memory when loading a *lot* of comments. So instead we generate a new string everytime.
 
Another solution (to keep the herped string the same) would be to stop generating a random string and to instead use the base comment, hash it in some way and to use that hash to generate a herped comment. But that's too much a departure from the original algorithm, so unless you want me to do it this way I won't.