### PR TITLE
Update horrible selector string for Chrome/FF

### DIFF
--- a/chrome+firefox/src/index.js
+++ b/chrome+firefox/src/index.js
@@ -58,7 +58,7 @@ const checkCommentsLoaded = () => {
   setTimeout(() => {
     // This selector is awful, but Youtube re-uses a lot of the DOM (the selector for the comments is re-used across a bunch of pages) so we need the exact path to the comments to match
     const commentsSection = document.querySelector(
-      "html body ytd-app div#content.style-scope.ytd-app ytd-page-manager#page-manager.style-scope.ytd-app ytd-watch.style-scope.ytd-page-manager.hide-skeleton div#top.style-scope.ytd-watch div#container.style-scope.ytd-watch div#main.style-scope.ytd-watch ytd-comments#comments.style-scope.ytd-watch ytd-item-section-renderer#sections.style-scope.ytd-comments div#contents.style-scope.ytd-item-section-renderer"
+      "html body ytd-app div#content.style-scope.ytd-app ytd-page-manager#page-manager.style-scope.ytd-app ytd-watch-flexy.style-scope.ytd-page-manager.hide-skeleton div#columns.style-scope.ytd-watch-flexy div#primary.style-scope.ytd-watch-flexy div#primary-inner.style-scope.ytd-watch-flexy ytd-comments#comments.style-scope.ytd-watch-flexy ytd-item-section-renderer#sections.style-scope.ytd-comments div#contents.style-scope.ytd-item-section-renderer"
     );
     if (commentsSection !== null) init(commentsSection);
     else checkCommentsLoaded();


### PR DESCRIPTION
Howdy,

This has been nonfunctional for me for a little while on Chrome,
seems the class selector for the comment section has changed.
This new absolute selector fixes the issue for me.

Test Plan: It Works On My Machine(tm)

Tested on Chrome 69 and Firefox 62, light and dark mode

Cheers,
Denbeigh