### PR TITLE
Fix all-herp/all-derp problem

### DIFF
--- a/chrome+firefox/src/herp.js
+++ b/chrome+firefox/src/herp.js
@@ -4,9 +4,9 @@ const randomInt = max => Math.floor(Math.random() * max);
 // builds a string with random herps and derps
 const derpString = (length = 20) => {
   const randomLength = randomInt(length) + 1;
-  const randomDerp = randomInt(2) ? "herp" : "derp";
+  const randomDerp = () => randomInt(2) ? "herp" : "derp";
 
-  return Array.from({ length: randomLength }, () => randomDerp).join(" ");
+  return Array.from({ length: randomLength }, randomDerp).join(" ");
 };
 
 // herp derps an element


### PR DESCRIPTION
Hello,

This fixes an issue in Firefox (and presumably Chrome) where all
comments were either all "herp" or all "derp", and instead replaces them
with comments interspersed with both "herp" and "derp".

Tested on Firefox 66.